### PR TITLE
Horizontal Scroll Bar + enabling multi-line column headers

### DIFF
--- a/src/components/Shared/Table.css
+++ b/src/components/Shared/Table.css
@@ -1,6 +1,14 @@
+.tableWrapper {
+    overflow-x: auto;   /* 1: Enables horizontal scrolling when needed */
+    width: 100%;        /* 2: Ensures wrapper stretches full width */
+}
+
+
+
+
 table.responsiveTable {
     border-collapse: collapse;
-    table-layout: fixed !important;
+    min-width: max-content !important;
     max-width: 100% !important;
 }
 
@@ -10,9 +18,12 @@ table.responsiveTable td {
     padding-left: 10px;
 }
 
+
+
 table.responsiveTable > thead {
     background-color: #FFE082;
     color: black;
+    text-align: center;
 }
 
 .tableRows {

--- a/src/components/Shared/Table.js
+++ b/src/components/Shared/Table.js
@@ -16,12 +16,26 @@ const isValidUrl = (url) => {
 };
 
 
+
 export const CreateTable = (data, columns, deleteFunction, editFunction) => (
   <div className="tableWrapper">
-  <Table className="responsiveTable">
-    <Thead>
-      <Tr>
-        {columns.map(x =>  <Th key={x}>{x}</Th>)}
+    <Table className="responsiveTable">
+      <Thead>
+        <Tr>
+          {columns.map((col, idx) => (
+           <Th key={`col-${idx}`}>
+             {col.includes(" ")
+               ? col.split(" ").map((word, i) => (
+                   <React.Fragment key={i}>
+                     {word}
+                     <br />
+                   </React.Fragment>
+                 ))
+               : col}
+           </Th>
+         ))}
+
+
         {(deleteFunction || editFunction)
           ? (
             <Th key="actions"></Th>


### PR DESCRIPTION
The current CreateTable function does not receive the column names with spaces, ie. "ArtStatus" , "WordCount". The code provided separates columns names WITH spaces:
Test code (when the CreateTable function is given  column names with spaces):
<img width="680" height="332" alt="Screenshot 2025-11-24 at 10 17 23 AM" src="https://github.com/user-attachments/assets/255484a3-d49b-49f6-a3d5-31a1d8083b2f" />
Result:
<img width="1500" height="763" alt="Screenshot 2025-11-24 at 10 15 44 AM" src="https://github.com/user-attachments/assets/7a34a014-0f1b-4b93-8d5d-a574cdc6c4d1" />

Horizontal scroll bar tested:
<img width="1512" height="784" alt="Screenshot 2025-11-24 at 1 04 43 PM" src="https://github.com/user-attachments/assets/a2e87be1-d731-4a49-952d-215187f5dd51" />
